### PR TITLE
API update

### DIFF
--- a/contracts/cw-graph/src/contract.rs
+++ b/contracts/cw-graph/src/contract.rs
@@ -6,7 +6,7 @@ use cw2::set_contract_version;
 use crate::error::ContractError;
 use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_named_cyberlinks, query_state, query_cyberlinks_set_by_ids};
+use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_cyberlinks_by_ids, query_state, query_cyberlinks_set_by_ids, query_cyberlinks_by_type, query_cyberlinks_by_from, query_cyberlinks_by_to, query_cyberlinks_by_owner_and_type, query_get_counts};
 use crate::semcores::SemanticCore;
 use crate::state::{cyberlinks, Config, CyberlinkState, CONFIG, ID, NAMED_CYBERLINKS};
 
@@ -119,7 +119,7 @@ pub fn execute(
         ExecuteMsg::CreateNamedCyberlink { name, cyberlink } => execute_create_named_cyberlink(deps, env, info, name, cyberlink),
         ExecuteMsg::CreateCyberlink { cyberlink } => execute_create_cyberlink(deps, env, info, cyberlink),
         ExecuteMsg::CreateCyberlinks { cyberlinks } => execute_create_cyberlinks(deps, env, info, cyberlinks),
-        ExecuteMsg::UpdateCyberlink { id, cyberlink } => execute_update_cyberlink(deps, env, info, id, cyberlink),
+        ExecuteMsg::UpdateCyberlink { id, value } => execute_update_cyberlink(deps, env, info, id, value),
         ExecuteMsg::DeleteCyberlink { id } => execute_delete_cyberlink(deps, env, info, id),
         ExecuteMsg::UpdateAdmins { new_admins } => execute_update_admins(deps, env, info, new_admins),
         ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors)
@@ -131,6 +131,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::DebugState {} => to_json_binary(&query_state(deps)?),
+        QueryMsg::GetCounts { owner, type_ } => to_json_binary(&query_get_counts(deps, owner, type_)?),
         
         QueryMsg::LastGID {} => to_json_binary(&query_last_gid(deps)?),
         QueryMsg::CyberlinkByGID { gid: id } => to_json_binary(&query_cyberlink_by_gid(deps, id)?),
@@ -138,7 +139,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::CyberlinksSetByGIDs { ids } => to_json_binary(&query_cyberlinks_set_by_gids(deps, ids)?),
         
         QueryMsg::CyberlinkByID { id } => to_json_binary(&query_cyberlink_by_formatted_id(deps, id)?),
-        QueryMsg::CyberlinksByIDs { start_after, limit } => to_json_binary(&query_named_cyberlinks(deps, start_after, limit)?),
+        QueryMsg::CyberlinksByIDs { start_after, limit } => to_json_binary(&query_cyberlinks_by_ids(deps, start_after, limit)?),
         QueryMsg::CyberlinksSetByIDs { ids } => to_json_binary(&query_cyberlinks_set_by_ids(deps, ids)?),
         
         QueryMsg::CyberlinksByOwner { owner, start_after, limit } => to_json_binary(&query_cyberlinks_by_owner(deps, owner, start_after, limit)?),
@@ -146,6 +147,11 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&query_cyberlinks_by_owner_time(deps, env, owner, start_time, end_time, start_after, limit)?),
         QueryMsg::CyberlinksByOwnerTimeAny { owner, start_time, end_time, start_after, limit } =>
             to_json_binary(&query_cyberlinks_by_owner_time_any(deps, env, owner, start_time, end_time, start_after, limit)?),
+
+        QueryMsg::CyberlinksByType { type_, start_after, limit } => to_json_binary(&query_cyberlinks_by_type(deps, type_, start_after, limit)?),
+        QueryMsg::CyberlinksByFrom { from, start_after, limit } => to_json_binary(&query_cyberlinks_by_from(deps, from, start_after, limit)?),
+        QueryMsg::CyberlinksByTo { to, start_after, limit } => to_json_binary(&query_cyberlinks_by_to(deps, to, start_after, limit)?),
+        QueryMsg::CyberlinksByOwnerAndType { owner, type_, start_after, limit } => to_json_binary(&query_cyberlinks_by_owner_and_type(deps, owner, type_, start_after, limit)?),
     }
 }
 

--- a/contracts/cw-graph/src/contract.rs
+++ b/contracts/cw-graph/src/contract.rs
@@ -6,7 +6,7 @@ use cw2::set_contract_version;
 use crate::error::ContractError;
 use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks, query_cyberlinks_by_ids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_id, query_last_id, query_named_cyberlinks, query_state};
+use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_named_cyberlinks, query_state, query_cyberlinks_set_by_ids};
 use crate::semcores::SemanticCore;
 use crate::state::{cyberlinks, Config, CyberlinkState, CONFIG, ID, NAMED_CYBERLINKS};
 
@@ -129,14 +129,18 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::LastId {} => to_json_binary(&query_last_id(deps)?),
-        QueryMsg::DebugState {} => to_json_binary(&query_state(deps)?),
         QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
-        QueryMsg::Cyberlink { id } => to_json_binary(&query_id(deps, id)?),
-        QueryMsg::CyberlinkById { id: formatted_id } => to_json_binary(&query_cyberlink_by_formatted_id(deps, formatted_id)?),
-        QueryMsg::Cyberlinks { start_after, limit} => to_json_binary(&query_cyberlinks(deps, start_after, limit)?),
-        QueryMsg::CyberlinksByIds { ids } => to_json_binary(&query_cyberlinks_by_ids(deps, ids)?),
-        QueryMsg::NamedCyberlinks { start_after, limit } => to_json_binary(&query_named_cyberlinks(deps, start_after, limit)?),
+        QueryMsg::DebugState {} => to_json_binary(&query_state(deps)?),
+        
+        QueryMsg::LastGID {} => to_json_binary(&query_last_gid(deps)?),
+        QueryMsg::CyberlinkByGID { gid: id } => to_json_binary(&query_cyberlink_by_gid(deps, id)?),
+        QueryMsg::CyberlinksByGIDs { start_after, limit} => to_json_binary(&query_cyberlinks_by_gids(deps, start_after, limit)?),
+        QueryMsg::CyberlinksSetByGIDs { ids } => to_json_binary(&query_cyberlinks_set_by_gids(deps, ids)?),
+        
+        QueryMsg::CyberlinkByID { id } => to_json_binary(&query_cyberlink_by_formatted_id(deps, id)?),
+        QueryMsg::CyberlinksByIDs { start_after, limit } => to_json_binary(&query_named_cyberlinks(deps, start_after, limit)?),
+        QueryMsg::CyberlinksSetByIDs { ids } => to_json_binary(&query_cyberlinks_set_by_ids(deps, ids)?),
+        
         QueryMsg::CyberlinksByOwner { owner, start_after, limit } => to_json_binary(&query_cyberlinks_by_owner(deps, owner, start_after, limit)?),
         QueryMsg::CyberlinksByOwnerTime { owner, start_time, end_time, start_after, limit } =>
             to_json_binary(&query_cyberlinks_by_owner_time(deps, env, owner, start_time, end_time, start_after, limit)?),

--- a/contracts/cw-graph/src/contract.rs
+++ b/contracts/cw-graph/src/contract.rs
@@ -6,9 +6,9 @@ use cw2::set_contract_version;
 use crate::error::ContractError;
 use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_cyberlinks_by_ids, query_state, query_cyberlinks_set_by_ids, query_cyberlinks_by_type, query_cyberlinks_by_from, query_cyberlinks_by_to, query_cyberlinks_by_owner_and_type, query_get_counts};
+use crate::query::{query_config, query_cyberlink_by_fid, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_cyberlinks_by_fids, query_state, query_cyberlinks_set_by_fids, query_cyberlinks_by_type, query_cyberlinks_by_from, query_cyberlinks_by_to, query_cyberlinks_by_owner_and_type, query_graph_stats};
 use crate::semcores::SemanticCore;
-use crate::state::{cyberlinks, Config, CyberlinkState, CONFIG, ID, NAMED_CYBERLINKS};
+use crate::state::{cyberlinks, Config, CyberlinkState, CONFIG, GID, NAMED_CYBERLINKS};
 
 const CONTRACT_NAME: &str = "crates.io:cw-graph";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -28,7 +28,7 @@ pub fn instantiate(
     };
     CONFIG.save(deps.storage, &config)?;
 
-    ID.save(deps.storage, &0)?;
+    GID.save(deps.storage, &0)?;
 
     // Initialize base types
     create_base_types(deps.branch(), &env, &info)?;
@@ -45,8 +45,8 @@ pub fn instantiate(
 
 fn create_base_types(deps: DepsMut, env: &Env, info: &MessageInfo) -> Result<(), ContractError> {
     // Create Type and Any types as before
-    let id = ID.load(deps.storage)? + 1;
-    ID.save(deps.storage, &id)?;
+    let id = GID.load(deps.storage)? + 1;
+    GID.save(deps.storage, &id)?;
     cyberlinks().save(deps.storage, id, &CyberlinkState {
         type_: "Type".to_string(),
         from: "Any".to_string(),
@@ -55,13 +55,13 @@ fn create_base_types(deps: DepsMut, env: &Env, info: &MessageInfo) -> Result<(),
         owner: info.sender.clone(),
         created_at: env.block.time,
         updated_at: None,
-        formatted_id: Some("".to_string()),
+        fid: Some("".to_string()),
     })?;
     NAMED_CYBERLINKS.save(deps.storage, "Type", &id)?;
 
     // Create Any type
-    let id = ID.load(deps.storage)? + 1;
-    ID.save(deps.storage, &id)?;
+    let id = GID.load(deps.storage)? + 1;
+    GID.save(deps.storage, &id)?;
     cyberlinks().save(deps.storage, id, &CyberlinkState {
         type_: "Any".to_string(),
         from: "Null".to_string(),
@@ -70,7 +70,7 @@ fn create_base_types(deps: DepsMut, env: &Env, info: &MessageInfo) -> Result<(),
         owner: info.sender.clone(),
         created_at: env.block.time,
         updated_at: None,
-        formatted_id: Some("".to_string()),
+        fid: Some("".to_string()),
     })?;
     NAMED_CYBERLINKS.save(deps.storage, "Any", &id)?;
     Ok(())
@@ -82,8 +82,8 @@ fn load_semantic_core(deps: DepsMut, env: &Env, info: &MessageInfo, core: Semant
     for type_def in types {
         // Skip entries without an ID (already filtered in get_types, but just to be safe)
         if let Some(id_value) = &type_def.id {
-            let id = ID.load(deps.storage)? + 1;
-            ID.save(deps.storage, &id)?;
+            let id = GID.load(deps.storage)? + 1;
+            GID.save(deps.storage, &id)?;
             
             let cyberlink_state = CyberlinkState {
                 type_: type_def.type_,
@@ -93,7 +93,7 @@ fn load_semantic_core(deps: DepsMut, env: &Env, info: &MessageInfo, core: Semant
                 owner: info.sender.clone(),
                 created_at: env.block.time,
                 updated_at: None,
-                formatted_id: Some("".to_string()),
+                fid: Some("".to_string()),
             };
 
             cyberlinks().save(deps.storage, id, &cyberlink_state)?;
@@ -119,8 +119,8 @@ pub fn execute(
         ExecuteMsg::CreateNamedCyberlink { name, cyberlink } => execute_create_named_cyberlink(deps, env, info, name, cyberlink),
         ExecuteMsg::CreateCyberlink { cyberlink } => execute_create_cyberlink(deps, env, info, cyberlink),
         ExecuteMsg::CreateCyberlinks { cyberlinks } => execute_create_cyberlinks(deps, env, info, cyberlinks),
-        ExecuteMsg::UpdateCyberlink { id, value } => execute_update_cyberlink(deps, env, info, id, value),
-        ExecuteMsg::DeleteCyberlink { id } => execute_delete_cyberlink(deps, env, info, id),
+        ExecuteMsg::UpdateCyberlink { fid: id, value } => execute_update_cyberlink(deps, env, info, id, value),
+        ExecuteMsg::DeleteCyberlink { fid: id } => execute_delete_cyberlink(deps, env, info, id),
         ExecuteMsg::UpdateAdmins { new_admins } => execute_update_admins(deps, env, info, new_admins),
         ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors)
     }
@@ -131,27 +131,27 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::DebugState {} => to_json_binary(&query_state(deps)?),
-        QueryMsg::GetCounts { owner, type_ } => to_json_binary(&query_get_counts(deps, owner, type_)?),
+        QueryMsg::GetGraphStats { owner, type_ } => to_json_binary(&query_graph_stats(deps, owner, type_)?),
         
         QueryMsg::LastGID {} => to_json_binary(&query_last_gid(deps)?),
-        QueryMsg::CyberlinkByGID { gid: id } => to_json_binary(&query_cyberlink_by_gid(deps, id)?),
-        QueryMsg::CyberlinksByGIDs { start_after, limit} => to_json_binary(&query_cyberlinks_by_gids(deps, start_after, limit)?),
-        QueryMsg::CyberlinksSetByGIDs { ids } => to_json_binary(&query_cyberlinks_set_by_gids(deps, ids)?),
+        QueryMsg::CyberlinkByGID { gid } => to_json_binary(&query_cyberlink_by_gid(deps, gid)?),
+        QueryMsg::CyberlinksByGIDs { start_after_gid, limit} => to_json_binary(&query_cyberlinks_by_gids(deps, start_after_gid, limit)?),
+        QueryMsg::CyberlinksSetByGIDs { gids } => to_json_binary(&query_cyberlinks_set_by_gids(deps, gids)?),
         
-        QueryMsg::CyberlinkByID { id } => to_json_binary(&query_cyberlink_by_formatted_id(deps, id)?),
-        QueryMsg::CyberlinksByIDs { start_after, limit } => to_json_binary(&query_cyberlinks_by_ids(deps, start_after, limit)?),
-        QueryMsg::CyberlinksSetByIDs { ids } => to_json_binary(&query_cyberlinks_set_by_ids(deps, ids)?),
+        QueryMsg::CyberlinkByFID { fid } => to_json_binary(&query_cyberlink_by_fid(deps, fid)?),
+        QueryMsg::CyberlinksByFIDs { start_after_fid, limit } => to_json_binary(&query_cyberlinks_by_fids(deps, start_after_fid, limit)?),
+        QueryMsg::CyberlinksSetByFIDs { fids } => to_json_binary(&query_cyberlinks_set_by_fids(deps, fids)?),
         
-        QueryMsg::CyberlinksByOwner { owner, start_after, limit } => to_json_binary(&query_cyberlinks_by_owner(deps, owner, start_after, limit)?),
-        QueryMsg::CyberlinksByOwnerTime { owner, start_time, end_time, start_after, limit } =>
-            to_json_binary(&query_cyberlinks_by_owner_time(deps, env, owner, start_time, end_time, start_after, limit)?),
-        QueryMsg::CyberlinksByOwnerTimeAny { owner, start_time, end_time, start_after, limit } =>
-            to_json_binary(&query_cyberlinks_by_owner_time_any(deps, env, owner, start_time, end_time, start_after, limit)?),
+        QueryMsg::CyberlinksByOwner { owner, start_after_gid, limit } => to_json_binary(&query_cyberlinks_by_owner(deps, owner, start_after_gid, limit)?),
+        QueryMsg::CyberlinksByOwnerTime { owner, start_time, end_time, start_after_gid, limit } =>
+            to_json_binary(&query_cyberlinks_by_owner_time(deps, env, owner, start_time, end_time, start_after_gid, limit)?),
+        QueryMsg::CyberlinksByOwnerTimeAny { owner, start_time, end_time, start_after_gid, limit } =>
+            to_json_binary(&query_cyberlinks_by_owner_time_any(deps, env, owner, start_time, end_time, start_after_gid, limit)?),
 
-        QueryMsg::CyberlinksByType { type_, start_after, limit } => to_json_binary(&query_cyberlinks_by_type(deps, type_, start_after, limit)?),
-        QueryMsg::CyberlinksByFrom { from, start_after, limit } => to_json_binary(&query_cyberlinks_by_from(deps, from, start_after, limit)?),
-        QueryMsg::CyberlinksByTo { to, start_after, limit } => to_json_binary(&query_cyberlinks_by_to(deps, to, start_after, limit)?),
-        QueryMsg::CyberlinksByOwnerAndType { owner, type_, start_after, limit } => to_json_binary(&query_cyberlinks_by_owner_and_type(deps, owner, type_, start_after, limit)?),
+        QueryMsg::CyberlinksByType { type_, start_after_gid, limit } => to_json_binary(&query_cyberlinks_by_type(deps, type_, start_after_gid, limit)?),
+        QueryMsg::CyberlinksByFrom { from, start_after_gid, limit } => to_json_binary(&query_cyberlinks_by_from(deps, from, start_after_gid, limit)?),
+        QueryMsg::CyberlinksByTo { to, start_after_gid, limit } => to_json_binary(&query_cyberlinks_by_to(deps, to, start_after_gid, limit)?),
+        QueryMsg::CyberlinksByOwnerAndType { owner, type_, start_after_gid, limit } => to_json_binary(&query_cyberlinks_by_owner_and_type(deps, owner, type_, start_after_gid, limit)?),
     }
 }
 

--- a/contracts/cw-graph/src/error.rs
+++ b/contracts/cw-graph/src/error.rs
@@ -3,15 +3,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
-    #[error("Deleted cyberlink: {id}")]
-    DeletedCyberlink { id: String },
+    #[error("Deleted cyberlink: {fid}")]
+    DeletedCyberlink { fid: String },
 
-    #[error("Not found: {id}")]
-    NotFound { id: String },
+    #[error("Not found: {fid}")]
+    NotFound { fid: String },
 
     // TODO: revisit and change to id: String
-    #[error("Particular links is not allowed id: {id}, from: {from}, to: {to}, type: {type_}")]
-    InvalidCyberlink {id: Uint64, from: String, to: String, type_: String},
+    #[error("Particular links is not allowed - from: {from}, to: {to}, type: {type_}")]
+    InvalidCyberlink {from: String, to: String, type_: String},
 
     #[error("Type not exists: {type_}")]
     TypeNotExists { type_: String },

--- a/contracts/cw-graph/src/msg.rs
+++ b/contracts/cw-graph/src/msg.rs
@@ -66,27 +66,37 @@ pub enum QueryMsg {
     
     // Global IDs API
     #[returns(Uint64)]
-    LastId {},
+    LastGID {},
     #[returns(CyberlinkState)]
-    Cyberlink {
-        id: Uint64,
+    CyberlinkByGID {
+        gid: Uint64,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
-    Cyberlinks {
+    CyberlinksByGIDs {
         start_after: Option<u64>,
         limit: Option<u32>,
     },
+    #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksSetByGIDs {
+        ids: Vec<u64>,
+    },
 
     // Formatted IDs API (default IDs)
+    #[returns(CyberlinkState)]
+    CyberlinkByID {
+        id: String,
+    },
     #[returns(Vec<(String, CyberlinkState)>)]
-    NamedCyberlinks {
+    CyberlinksByIDs {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    #[returns(Vec<(u64, CyberlinkState)>)]
-    CyberlinksByIds {
-        ids: Vec<u64>,
+    #[returns(Vec<(String, CyberlinkState)>)]
+    CyberlinksSetByIDs {
+        ids: Vec<String>,
     },
+
+    // Formatted IDs API (WIP)
     #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByOwner {
         owner: String,
@@ -108,9 +118,5 @@ pub enum QueryMsg {
         end_time: Option<Timestamp>,
         start_after: Option<u64>,
         limit: Option<u32>,
-    },
-    #[returns(CyberlinkState)]
-    CyberlinkById {
-        id: String,
     },
 }

--- a/contracts/cw-graph/src/msg.rs
+++ b/contracts/cw-graph/src/msg.rs
@@ -42,11 +42,11 @@ pub enum ExecuteMsg {
         cyberlinks: Vec<Cyberlink>,
     },
     UpdateCyberlink {
-        id: String,
+        fid: String,
         value: Option<String>,
     },
     DeleteCyberlink {
-        id: String,
+        fid: String,
     },
     UpdateAdmins {
         new_admins: Vec<String>
@@ -59,6 +59,14 @@ pub enum ExecuteMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
+    #[returns(CountsResponse)]
+    GetGraphStats {
+        // If owner is Some, returns owner_count and owner_type_count (if type_ is also Some)
+        owner: Option<String>,
+        // If type_ is Some, returns type_count and owner_type_count (if owner is also Some)
+        #[serde(rename = "type")]
+        type_: Option<String>,
+    },
     #[returns(ConfigResponse)]
     Config {},
     #[returns(StateResponse)]
@@ -73,53 +81,53 @@ pub enum QueryMsg {
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByGIDs {
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksSetByGIDs {
-        ids: Vec<u64>,
+        gids: Vec<u64>,
     },
 
     // Formatted IDs API (default IDs)
     #[returns(CyberlinkState)]
-    CyberlinkByID {
-        id: String,
+    CyberlinkByFID {
+        fid: String,
     },
     #[returns(Vec<(String, CyberlinkState)>)]
-    CyberlinksByIDs {
-        start_after: Option<String>,
+    CyberlinksByFIDs {
+        start_after_fid: Option<String>,
         limit: Option<u32>,
     },
     #[returns(Vec<(String, CyberlinkState)>)]
-    CyberlinksSetByIDs {
-        ids: Vec<String>,
+    CyberlinksSetByFIDs {
+        fids: Vec<String>,
     },
 
     // Formatted IDs API (WIP)
     #[returns(Vec<(u64, CyberlinkState)>)]
-    CyberlinksByOwner {
-        owner: String,
-        start_after: Option<u64>,
-        limit: Option<u32>,
-    },
-    #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByType {
         #[serde(rename = "type")]
         type_: String,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByFrom {
         from: String,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByTo {
         to: String,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksByOwner {
+        owner: String,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
@@ -127,7 +135,7 @@ pub enum QueryMsg {
         owner: String,
         start_time: Timestamp,
         end_time: Option<Timestamp>,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
@@ -135,7 +143,7 @@ pub enum QueryMsg {
         owner: String,
         start_time: Timestamp,
         end_time: Option<Timestamp>,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
@@ -143,18 +151,8 @@ pub enum QueryMsg {
         owner: String,
         #[serde(rename = "type")]
         type_: String,
-        start_after: Option<u64>,
+        start_after_gid: Option<u64>,
         limit: Option<u32>,
-    },
-
-    // Tier 4: Aggregation (Stateful Counts)
-    #[returns(CountsResponse)]
-    GetCounts {
-        // If owner is Some, returns owner_count and owner_type_count (if type_ is also Some)
-        owner: Option<String>,
-        // If type_ is Some, returns type_count and owner_type_count (if owner is also Some)
-        #[serde(rename = "type")]
-        type_: Option<String>,
     },
 }
 

--- a/contracts/cw-graph/src/msg.rs
+++ b/contracts/cw-graph/src/msg.rs
@@ -43,7 +43,7 @@ pub enum ExecuteMsg {
     },
     UpdateCyberlink {
         id: String,
-        cyberlink: Cyberlink,
+        value: Option<String>,
     },
     DeleteCyberlink {
         id: String,
@@ -104,6 +104,25 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksByType {
+        #[serde(rename = "type")]
+        type_: String,
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksByFrom {
+        from: String,
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksByTo {
+        to: String,
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<(u64, CyberlinkState)>)]
     CyberlinksByOwnerTime {
         owner: String,
         start_time: Timestamp,
@@ -119,4 +138,30 @@ pub enum QueryMsg {
         start_after: Option<u64>,
         limit: Option<u32>,
     },
+    #[returns(Vec<(u64, CyberlinkState)>)]
+    CyberlinksByOwnerAndType {
+        owner: String,
+        #[serde(rename = "type")]
+        type_: String,
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+
+    // Tier 4: Aggregation (Stateful Counts)
+    #[returns(CountsResponse)]
+    GetCounts {
+        // If owner is Some, returns owner_count and owner_type_count (if type_ is also Some)
+        owner: Option<String>,
+        // If type_ is Some, returns type_count and owner_type_count (if owner is also Some)
+        #[serde(rename = "type")]
+        type_: Option<String>,
+    },
+}
+
+// Response struct for count queries
+#[cw_serde]
+pub struct CountsResponse {
+    pub owner_count: Option<Uint64>,
+    pub type_count: Option<Uint64>,
+    pub owner_type_count: Option<Uint64>,
 }

--- a/contracts/cw-graph/src/state.rs
+++ b/contracts/cw-graph/src/state.rs
@@ -30,6 +30,7 @@ pub struct CyberlinkIndices<'a> {
     // Index by to
     pub to: MultiIndex<'a, String, CyberlinkState, u64>,
     
+    // TODO WIP complex indexes in design stage
     pub created_at: MultiIndex<'a, (Addr, u64), CyberlinkState, u64>,
     pub updated_at: MultiIndex<'a, (Addr, u64), CyberlinkState, u64>,
     // Index by formatted_id

--- a/contracts/cw-graph/src/state.rs
+++ b/contracts/cw-graph/src/state.rs
@@ -5,6 +5,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
 #[cw_serde]
 pub struct CyberlinkState {
+    pub fid: Option<String>,
     #[serde(rename = "type")]
     pub type_: String,
     pub from: String,
@@ -13,7 +14,6 @@ pub struct CyberlinkState {
     pub owner: Addr,
     pub created_at: Timestamp,
     pub updated_at: Option<Timestamp>,
-    pub formatted_id: Option<String>,
 }
 
 // Define the primary key namespace
@@ -29,12 +29,11 @@ pub struct CyberlinkIndices<'a> {
     pub from: MultiIndex<'a, String, CyberlinkState, u64>,
     // Index by to
     pub to: MultiIndex<'a, String, CyberlinkState, u64>,
-    
+    // Index by formatted_id
+    pub fid: MultiIndex<'a, String, CyberlinkState, u64>,
     // Index by owner and type (composite)
     pub owner_type: MultiIndex<'a, (Addr, String), CyberlinkState, u64>,
-    // Index by formatted_id
-    pub formatted_id: MultiIndex<'a, String, CyberlinkState, u64>,
-
+    
     // TODO WIP in design stage
     pub created_at: MultiIndex<'a, (Addr, u64), CyberlinkState, u64>,
     pub updated_at: MultiIndex<'a, (Addr, u64), CyberlinkState, u64>,
@@ -46,7 +45,7 @@ impl<'a> IndexList<CyberlinkState> for CyberlinkIndices<'a> {
         let v: Vec<&dyn Index<CyberlinkState>> = vec![
             &self.owner, &self.type_, &self.from, &self.to, 
             &self.owner_type,
-            &self.created_at, &self.updated_at, &self.formatted_id
+            &self.created_at, &self.updated_at, &self.fid
         ];
         Box::new(v.into_iter())
     }
@@ -75,13 +74,11 @@ pub fn cyberlinks<'a>() -> IndexedMap<u64, CyberlinkState, CyberlinkIndices<'a>>
             CYBERLINKS_KEY,
             "cyberlinks__to",
         ),
-        
         owner_type: MultiIndex::new(
             |_pk, d: &CyberlinkState| (d.owner.clone(), d.type_.clone()),
             CYBERLINKS_KEY,
             "cyberlinks__owner_type",
         ),
-
         created_at: MultiIndex::new(
             |_pk, d: &CyberlinkState| (d.owner.clone(), d.created_at.nanos()),
             CYBERLINKS_KEY,
@@ -92,10 +89,10 @@ pub fn cyberlinks<'a>() -> IndexedMap<u64, CyberlinkState, CyberlinkIndices<'a>>
             CYBERLINKS_KEY,
             "cyberlinks__updated_at",
         ),
-        formatted_id: MultiIndex::new(
-            |pk, d: &CyberlinkState| d.formatted_id.clone().unwrap_or_else(|| format!("root:{}-{:?}", d.owner, pk)),
+        fid: MultiIndex::new(
+            |pk, d: &CyberlinkState| d.fid.clone().unwrap_or_else(|| format!("root:{}-{:?}", d.owner, pk)),
             CYBERLINKS_KEY,
-            "cyberlinks__formatted_id",
+            "cyberlinks__fid",
         ),
     };
     IndexedMap::new(CYBERLINKS_KEY, indices)
@@ -106,16 +103,16 @@ pub const NAMED_CYBERLINKS_KEY: &str = "named_cyberlinks";
 pub const NAMED_CYBERLINKS: Map<&str, u64> = Map::new(NAMED_CYBERLINKS_KEY);
 
 // ID counter
-pub const ID_KEY: &str = "id";
-pub const ID: Item<u64> = Item::new(ID_KEY);
+pub const GID_KEY: &str = "gid";
+pub const GID: Item<u64> = Item::new(GID_KEY);
 
 // Type-specific ID counters
-pub const TYPE_ID_KEY: &str = "type_id";
-pub const TYPE_IDS: Map<&str, u64> = Map::new(TYPE_ID_KEY);
+pub const TYPE_GID_KEY: &str = "type_gid";
+pub const TYPE_GIDS: Map<&str, u64> = Map::new(TYPE_GID_KEY);
 
 // Deleted IDs tracking
-pub const DELETED_IDS_KEY: &str = "deleted_ids";
-pub const DELETED_IDS: Map<u64, bool> = Map::new(DELETED_IDS_KEY);
+pub const DELETED_GIDS_KEY: &str = "deleted_gids";
+pub const DELETED_GIDS: Map<u64, bool> = Map::new(DELETED_GIDS_KEY);
 
 #[cw_serde]
 pub struct Config {


### PR DESCRIPTION
This pull request introduces significant updates to the `cw-graph` contract, focusing on enhancing query functionality, improving cyberlink management, and introducing counters for tracking cyberlink statistics. Below is a summary of the most important changes:

### Query Enhancements
* Expanded the `QueryMsg` API to include new queries such as `CyberlinksByType`, `CyberlinksByFrom`, `CyberlinksByTo`, `CyberlinksByOwnerAndType`, and `GetCounts`, enabling more granular and aggregated data retrieval. [[1]](diffhunk://#diff-08f87ee7259a97ae3b512e692de00b9c1920ff7c5b718898aa4a41240928d8d2L132-R154) [[2]](diffhunk://#diff-40692fa0a07cdcde964c3265d31df726140404e789fd721370cab40120e3b4ccL69-R125) [[3]](diffhunk://#diff-40692fa0a07cdcde964c3265d31df726140404e789fd721370cab40120e3b4ccL112-R166)
* Replaced `LastId` and `Cyberlink` queries with `LastGID` and `CyberlinkByGID`, respectively, to align with the new global ID-based query system. [[1]](diffhunk://#diff-08f87ee7259a97ae3b512e692de00b9c1920ff7c5b718898aa4a41240928d8d2L132-R154) [[2]](diffhunk://#diff-40692fa0a07cdcde964c3265d31df726140404e789fd721370cab40120e3b4ccL69-R125)
* Introduced helper functions for querying cyberlinks by GIDs and sets of GIDs, improving the efficiency of batch queries. [[1]](diffhunk://#diff-f7ca5bad9e2eb47d5fb0a5ade3dd1ef9dffb0d77d6c060693f591ab74125b040L1-R15) [[2]](diffhunk://#diff-f7ca5bad9e2eb47d5fb0a5ade3dd1ef9dffb0d77d6c060693f591ab74125b040L56-R65)

### Cyberlink Management Updates
* Refactored `execute_update_cyberlink` to simplify updates by focusing on modifying the `value` field, ensuring immutability of other fields (e.g., `type`, `from`, `to`). [[1]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81L222-R275) [[2]](diffhunk://#diff-40692fa0a07cdcde964c3265d31df726140404e789fd721370cab40120e3b4ccL46-R46)
* Enhanced the `execute_delete_cyberlink` function to decrement counters and optionally remove cyberlink state for space optimization.

### Counter System for Cyberlink Statistics
* Added counters to track the number of cyberlinks by owner, type, and owner-type combinations. These counters are incremented during cyberlink creation and decremented during deletion. [[1]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81R123-R126) [[2]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81R352-R405)
* Introduced the `GetCounts` query to retrieve aggregated statistics for owners, types, and owner-type combinations.

These changes collectively improve the contract's query capabilities, streamline cyberlink updates, and provide statistical insights into cyberlink usage.