### PR TITLE
Add cyberlink2

### DIFF
--- a/contracts/cw-graph/src/contract.rs
+++ b/contracts/cw-graph/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{to_json_binary, Addr, Api, Binary, Deps, DepsMut, Empty, Env,
 use cw2::set_contract_version;
 
 use crate::error::ContractError;
-use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors, execute_create_vertex_and_link};
+use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors, execute_create_cyberlink2};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::query::{query_config, query_cyberlink_by_fid, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_cyberlinks_by_fids, query_state, query_cyberlinks_set_by_fids, query_cyberlinks_by_type, query_cyberlinks_by_from, query_cyberlinks_by_to, query_cyberlinks_by_owner_and_type, query_graph_stats};
 use crate::semcores::SemanticCore;
@@ -118,29 +118,29 @@ pub fn execute(
     match msg {
         ExecuteMsg::CreateNamedCyberlink { name, cyberlink } => execute_create_named_cyberlink(deps, env, info, name, cyberlink),
         ExecuteMsg::CreateCyberlink { cyberlink } => execute_create_cyberlink(deps, env, info, cyberlink),
-        ExecuteMsg::CreateCyberlinks { cyberlinks } => execute_create_cyberlinks(deps, env, info, cyberlinks),
-        ExecuteMsg::UpdateCyberlink { fid: id, value } => execute_update_cyberlink(deps, env, info, id, value),
-        ExecuteMsg::DeleteCyberlink { fid: id } => execute_delete_cyberlink(deps, env, info, id),
-        ExecuteMsg::UpdateAdmins { new_admins } => execute_update_admins(deps, env, info, new_admins),
-        ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors),
-        ExecuteMsg::CreateVertexAndLink {
-            vertex_type,
-            vertex_value,
+        ExecuteMsg::CreateCyberlink2 {
+            node_type,
+            node_value,
             link_type,
             link_value,
             link_from_existing_id,
             link_to_existing_id,
-        } => execute_create_vertex_and_link(
+        } => execute_create_cyberlink2(
             deps, 
             env, 
             info, 
-            vertex_type, 
-            vertex_value, 
+            node_type,
+            node_value,
             link_type, 
             link_value, 
             link_from_existing_id, 
             link_to_existing_id
         ),
+        ExecuteMsg::CreateCyberlinks { cyberlinks } => execute_create_cyberlinks(deps, env, info, cyberlinks),
+        ExecuteMsg::UpdateCyberlink { fid, value } => execute_update_cyberlink(deps, env, info, fid, value),
+        ExecuteMsg::DeleteCyberlink { fid } => execute_delete_cyberlink(deps, env, info, fid),
+        ExecuteMsg::UpdateAdmins { new_admins } => execute_update_admins(deps, env, info, new_admins),
+        ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors),
     }
 }
 

--- a/contracts/cw-graph/src/contract.rs
+++ b/contracts/cw-graph/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{to_json_binary, Addr, Api, Binary, Deps, DepsMut, Empty, Env,
 use cw2::set_contract_version;
 
 use crate::error::ContractError;
-use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors};
+use crate::execute::{execute_create_cyberlink, execute_create_cyberlinks, execute_create_named_cyberlink, execute_delete_cyberlink, execute_update_admins, execute_update_cyberlink, execute_update_executors, execute_create_vertex_and_link};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::query::{query_config, query_cyberlink_by_formatted_id, query_cyberlinks_by_gids, query_cyberlinks_set_by_gids, query_cyberlinks_by_owner, query_cyberlinks_by_owner_time, query_cyberlinks_by_owner_time_any, query_cyberlink_by_gid, query_last_gid, query_cyberlinks_by_ids, query_state, query_cyberlinks_set_by_ids, query_cyberlinks_by_type, query_cyberlinks_by_from, query_cyberlinks_by_to, query_cyberlinks_by_owner_and_type, query_get_counts};
 use crate::semcores::SemanticCore;
@@ -122,7 +122,25 @@ pub fn execute(
         ExecuteMsg::UpdateCyberlink { id, value } => execute_update_cyberlink(deps, env, info, id, value),
         ExecuteMsg::DeleteCyberlink { id } => execute_delete_cyberlink(deps, env, info, id),
         ExecuteMsg::UpdateAdmins { new_admins } => execute_update_admins(deps, env, info, new_admins),
-        ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors)
+        ExecuteMsg::UpdateExecutors { new_executors } => execute_update_executors(deps, env, info, new_executors),
+        ExecuteMsg::CreateVertexAndLink {
+            vertex_type,
+            vertex_value,
+            link_type,
+            link_value,
+            link_from_existing_id,
+            link_to_existing_id,
+        } => execute_create_vertex_and_link(
+            deps, 
+            env, 
+            info, 
+            vertex_type, 
+            vertex_value, 
+            link_type, 
+            link_value, 
+            link_from_existing_id, 
+            link_to_existing_id
+        ),
     }
 }
 

--- a/contracts/cw-graph/src/error.rs
+++ b/contracts/cw-graph/src/error.rs
@@ -22,14 +22,17 @@ pub enum ContractError {
     #[error("To not exists: {to}")]
     ToNotExists { to: String },
 
-    #[error("Type conflict \
-        link ( id: {id}, type: {type_}, from: {from}, to: {to} ),\
-        expected type: ( type: {expected_type}, from: {expected_from}, to: {expected_to} ),\
-        received_from: ( type: {received_type}, from: {received_from}, to: {received_to} )")]
+    #[error("Type conflict: link type '{type_}' connecting from '{from}' to '{to}'. Expected type: '{expected_type}' (constraints from: '{expected_from}', to: '{expected_to}'). Received type: '{received_type}' (actual from: '{received_from}', to: '{received_to}')")]
     TypeConflict {
-        id: String, type_: String, from: String, to: String,
-        expected_type: String, expected_from: String, expected_to: String,
-        received_type: String, received_from: String, received_to: String
+        type_: String,
+        from: String,
+        to: String,
+        expected_type: String,
+        expected_from: String,
+        expected_to: String,
+        received_type: String,
+        received_from: String,
+        received_to: String,
     },
 
     #[error("Cannot change cyberlink type: ID {id} from {original_type} to {new_type}")]

--- a/contracts/cw-graph/src/error.rs
+++ b/contracts/cw-graph/src/error.rs
@@ -58,6 +58,9 @@ pub enum ContractError {
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),
+
+    #[error("Invalid link specification: Exactly one of link_from_existing_id or link_to_existing_id must be provided")]
+    InvalidLinkSpecification {},
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/cw-graph/src/execute.rs
+++ b/contracts/cw-graph/src/execute.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{Deps, DepsMut, Env, MessageInfo, Response, Uint64, Storage, A
 
 fn validate_cyberlink(
     deps: Deps,
-    id: Option<String>,
+    fid: Option<String>,
     cyberlink: Cyberlink
 ) -> Result<(), ContractError> {
     // Validation
@@ -45,7 +45,6 @@ fn validate_cyberlink(
     if let (Some(_), Some(_)) = (&cyberlink.from, &cyberlink.to) {
         if dtype.clone().from.ne(&"Any") && dtype.clone().from.ne(&dfrom.clone().unwrap().type_) {
             return Err(ContractError::TypeConflict {
-                id: id.unwrap_or_else(|| "_".to_string()),
                 type_: cyberlink.clone().type_,
                 from: cyberlink.clone().from.unwrap_or_else(|| "_".to_string()),
                 to: cyberlink.clone().to.unwrap_or_else(|| "_".to_string()),
@@ -60,7 +59,6 @@ fn validate_cyberlink(
 
         if dtype.to.ne(&"Any") && dtype.to.ne(&dto.clone().unwrap().type_) {
             return Err(ContractError::TypeConflict {
-                id: id.unwrap_or_else(|| "_".to_string()),
                 type_: cyberlink.clone().type_,
                 from: cyberlink.clone().from.unwrap_or_else(|| "_".to_string()),
                 to: cyberlink.clone().to.unwrap_or_else(|| "_".to_string()),
@@ -402,135 +400,164 @@ fn decrement_counters(
     Ok(())
 }
 
-pub fn execute_create_vertex_and_link(
+fn validate_type_compatibility_for_cyberlink2(
+    link_type_state: &CyberlinkState,
+    node_type: &str, // Type of the node node being created
+    existing_node_state: &CyberlinkState, // State of the existing node being linked
+    link_from_new: bool, // True if the link is from the new node, false if to the new node
+    existing_node_fid: &str, // FID of the existing node for error reporting
+) -> Result<(), ContractError> {
+    if link_from_new { // Link: New -> Existing
+        // Check link_type's 'from' constraint against the new node's type
+        if link_type_state.from != "Any" && link_type_state.from != node_type {
+            return Err(ContractError::TypeConflict {
+                type_: link_type_state.type_.clone(),
+                from: "<new_node>".to_string(), // Placeholder as new FID isn't known yet
+                to: existing_node_fid.to_string(),
+                expected_type: link_type_state.type_.clone(),
+                expected_from: link_type_state.from.clone(),
+                expected_to: link_type_state.to.clone(),
+                received_type: link_type_state.type_.clone(),
+                received_from: node_type.to_string(),
+                received_to: existing_node_state.type_.clone(),
+            });
+        }
+        // Check link_type's 'to' constraint against the existing node's type
+        if link_type_state.to != "Any" && link_type_state.to != existing_node_state.type_ {
+            return Err(ContractError::TypeConflict {
+                type_: link_type_state.type_.clone(),
+                from: "<new_node>".to_string(),
+                to: existing_node_fid.to_string(),
+                expected_type: link_type_state.type_.clone(),
+                expected_from: link_type_state.from.clone(),
+                expected_to: link_type_state.to.clone(),
+                received_type: link_type_state.type_.clone(),
+                received_from: node_type.to_string(),
+                received_to: existing_node_state.type_.clone(),
+            });
+        }
+    } else { // Link: Existing -> New
+        // Check link_type's 'from' constraint against the existing node's type
+        if link_type_state.from != "Any" && link_type_state.from != existing_node_state.type_ {
+             return Err(ContractError::TypeConflict {
+                type_: link_type_state.type_.clone(),
+                from: existing_node_fid.to_string(),
+                to: "<new_node>".to_string(),
+                expected_type: link_type_state.type_.clone(),
+                expected_from: link_type_state.from.clone(),
+                expected_to: link_type_state.to.clone(),
+                received_type: link_type_state.type_.clone(),
+                received_from: existing_node_state.type_.clone(),
+                received_to: node_type.to_string(),
+             });
+        }
+        // Check link_type's 'to' constraint against the new node's type
+        if link_type_state.to != "Any" && link_type_state.to != node_type {
+             return Err(ContractError::TypeConflict {
+                type_: link_type_state.type_.clone(),
+                from: existing_node_fid.to_string(),
+                to: "<new_node>".to_string(),
+                expected_type: link_type_state.type_.clone(),
+                expected_from: link_type_state.from.clone(),
+                expected_to: link_type_state.to.clone(),
+                received_type: link_type_state.type_.clone(),
+                received_from: existing_node_state.type_.clone(),
+                received_to: node_type.to_string(),
+             });
+        }
+    }
+    Ok(())
+}
+
+pub fn execute_create_cyberlink2(
     mut deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    vertex_type: String,
-    vertex_value: Option<String>,
+    node_type: String,
+    node_value: Option<String>,
     link_type: String,
     link_value: Option<String>,
     link_from_existing_id: Option<String>,
     link_to_existing_id: Option<String>,
 ) -> Result<Response, ContractError> {
-    // 1. Authorization
-    let config = CONFIG.load(deps.storage)?;
-    if !config.can_execute(info.sender.as_str()) {
-        return Err(ContractError::Unauthorized {});
-    }
-
-    // 2. Input Validation
-    // 2.1 Link Specification
-    let (existing_vertex_id, link_from_new, link_to_new) = 
+    // Input Validation and Link Specification
+    let (existing_node_fid, link_from_new, _link_to_new) = // Renamed link_to_new as it's unused after this block
         match (link_from_existing_id.clone(), link_to_existing_id.clone()) {
             (Some(from_id), None) => (from_id, false, true), // Link FROM existing TO new
             (None, Some(to_id)) => (to_id, true, false),   // Link FROM new TO existing
             _ => return Err(ContractError::InvalidLinkSpecification {}),
         };
 
-    // 2.2 Type Existence
-    let vertex_type_gid = NAMED_CYBERLINKS.may_load(deps.storage, &vertex_type)?
-        .ok_or_else(|| ContractError::TypeNotExists { type_: vertex_type.clone() })?;
-    // Load vertex type state only if needed for strict validation later, otherwise existence check is enough
-    // let _vertex_type_state = cyberlinks().load(deps.storage, vertex_type_gid)?;
+    // Type Existence
+    let _node_type_gid = NAMED_CYBERLINKS.may_load(deps.storage, &node_type)? // Renamed to avoid shadowing
+        .ok_or_else(|| ContractError::TypeNotExists { type_: node_type.clone() })?;
+    // Load node type state only if needed for strict validation later, otherwise existence check is enough
+    // let _node_type_state = cyberlinks().load(deps.storage, node_type_gid)?;
     
     let link_type_gid = NAMED_CYBERLINKS.may_load(deps.storage, &link_type)?
         .ok_or_else(|| ContractError::TypeNotExists { type_: link_type.clone() })?;
     let link_type_state = cyberlinks().load(deps.storage, link_type_gid)?;
 
-    // 2.3 Existing Vertex Validation
-    let existing_vertex_gid = NAMED_CYBERLINKS.may_load(deps.storage, &existing_vertex_id)?
+    // Existing Node Validation
+    let existing_node_gid = NAMED_CYBERLINKS.may_load(deps.storage, &existing_node_fid)?
         .ok_or_else(|| {
             if link_from_new { // Linking TO existing, so it's a 'ToNotExists' error
-                ContractError::ToNotExists { to: existing_vertex_id.clone() }
+                ContractError::ToNotExists { to: existing_node_fid.clone() }
             } else { // Linking FROM existing, so it's a 'FromNotExists' error
-                ContractError::FromNotExists { from: existing_vertex_id.clone() }
+                ContractError::FromNotExists { from: existing_node_fid.clone() }
             }
         })?;
     
-    if DELETED_IDS.has(deps.storage, existing_vertex_gid) {
-        return Err(ContractError::NotFound { id: existing_vertex_id.clone() }); // Treat deleted as not found for linking
+    if DELETED_GIDS.has(deps.storage, existing_node_gid) {
+        return Err(ContractError::NotFound { fid: existing_node_fid.clone() }); // Treat deleted as not found for linking
     }
-    let existing_vertex_state = cyberlinks().load(deps.storage, existing_vertex_gid)?;
+    let existing_node_state = cyberlinks().load(deps.storage, existing_node_gid)?;
 
-    // 2.4 Type Compatibility Validation (Using loaded states)
-    // Check compatibility based on link direction relative to the NEW vertex
-    if link_from_new { // Link: New -> Existing
-        // Check link_type.from compatibility with new vertex_type
-        if link_type_state.from != "Any" && link_type_state.from != vertex_type {
-            return Err(ContractError::TypeConflict { /* ... detailed fields ... */ 
-                id: "<link> (new->existing)".to_string(), type_: link_type.clone(), 
-                from: "<new_vertex>".to_string(), to: existing_vertex_id.clone(),
-                expected_type: link_type.clone(), expected_from: link_type_state.from, expected_to: link_type_state.to,
-                received_type: link_type.clone(), received_from: vertex_type.clone(), received_to: existing_vertex_state.type_
-            });
-        }
-        // Check link_type.to compatibility with existing_vertex_state.type
-        if link_type_state.to != "Any" && link_type_state.to != existing_vertex_state.type_ {
-            return Err(ContractError::TypeConflict { /* ... detailed fields ... */
-                id: "<link> (new->existing)".to_string(), type_: link_type.clone(), 
-                from: "<new_vertex>".to_string(), to: existing_vertex_id.clone(),
-                expected_type: link_type.clone(), expected_from: link_type_state.from, expected_to: link_type_state.to,
-                received_type: link_type.clone(), received_from: vertex_type.clone(), received_to: existing_vertex_state.type_
-            });
-        }
-    } else { // Link: Existing -> New
-        // Check link_type.from compatibility with existing_vertex_state.type
-        if link_type_state.from != "Any" && link_type_state.from != existing_vertex_state.type_ {
-             return Err(ContractError::TypeConflict { /* ... detailed fields ... */
-                id: "<link> (existing->new)".to_string(), type_: link_type.clone(), 
-                from: existing_vertex_id.clone(), to: "<new_vertex>".to_string(),
-                expected_type: link_type.clone(), expected_from: link_type_state.from, expected_to: link_type_state.to,
-                received_type: link_type.clone(), received_from: existing_vertex_state.type_, received_to: vertex_type.clone()
-             });
-        }
-        // Check link_type.to compatibility with new vertex_type
-        if link_type_state.to != "Any" && link_type_state.to != vertex_type {
-             return Err(ContractError::TypeConflict { /* ... detailed fields ... */
-                id: "<link> (existing->new)".to_string(), type_: link_type.clone(), 
-                from: existing_vertex_id.clone(), to: "<new_vertex>".to_string(),
-                expected_type: link_type.clone(), expected_from: link_type_state.from, expected_to: link_type_state.to,
-                received_type: link_type.clone(), received_from: existing_vertex_state.type_, received_to: vertex_type.clone()
-             });
-        }
-    }
+    // Type Compatibility Validation (Using loaded states)
+    validate_type_compatibility_for_cyberlink2(
+        &link_type_state,
+        &node_type,
+        &existing_node_state,
+        link_from_new,
+        &existing_node_fid,
+    )?;
 
-    // 3. Create New Vertex
-    let vertex_cyberlink = Cyberlink {
-        type_: vertex_type,
+    // Create New Node
+    let node_cyberlink = Cyberlink {
+        type_: node_type, // Use validated node_type
         from: None, // Vertices are nodes, no from/to
         to: None,
-        value: vertex_value,
+        value: node_value,
     };
     // Use deps.branch() for the first creation to isolate potential state changes if create_cyberlink modified more state
-    let (new_vertex_gid, new_vertex_formatted_id) = 
-        create_cyberlink(deps.branch(), env.clone(), info.clone(), None, vertex_cyberlink)?;
+    let (node_gid, node_fid) = 
+        create_cyberlink(deps.branch(), env.clone(), info.clone(), None, node_cyberlink)?;
 
     // 4. Create Link
     let (link_from, link_to) = if link_from_new {
-        (Some(new_vertex_formatted_id.clone()), Some(existing_vertex_id.clone()))
+        (Some(node_fid.clone()), Some(existing_node_fid.clone()))
     } else {
-        (Some(existing_vertex_id.clone()), Some(new_vertex_formatted_id.clone()))
+        (Some(existing_node_fid.clone()), Some(node_fid.clone()))
     };
 
     let link_cyberlink = Cyberlink {
-        type_: link_type,
+        type_: link_type, // Use validated link_type
         from: link_from,
         to: link_to,
         value: link_value,
     };
     // Don't need validate_cyberlink here as create_cyberlink does necessary checks (like type existence)
     // and we performed the complex logic checks (like type compatibility) already.
-    let (link_gid, link_formatted_id) = 
+    let (link_gid, link_fid) = 
         create_cyberlink(deps, env, info, None, link_cyberlink)?;
 
     // 5. Response
     Ok(Response::new()
-        .add_attribute("action", "create_vertex_and_link")
-        .add_attribute("new_vertex_gid", new_vertex_gid.to_string())
-        .add_attribute("new_vertex_id", new_vertex_formatted_id)
+        .add_attribute("action", "create_cyberlink2")
+        .add_attribute("node_gid", node_gid.to_string())
+        .add_attribute("node_fid", node_fid)
         .add_attribute("link_gid", link_gid.to_string())
-        .add_attribute("link_id", link_formatted_id)
+        .add_attribute("link_fid", link_fid)
     )
 }
 

--- a/contracts/cw-graph/src/msg.rs
+++ b/contracts/cw-graph/src/msg.rs
@@ -54,20 +54,18 @@ pub enum ExecuteMsg {
     UpdateExecutors {
         new_executors: Vec<String>
     },
-    CreateVertexAndLink {
-        /// Data for the new vertex (node) to be created.
-        vertex_type: String,
-        vertex_value: Option<String>, // Optional value for the new vertex
-
+    CreateCyberlink2 {
+        /// Data for the new node to be created.
+        node_type: String,
+        node_value: Option<String>, // Optional value for the new node
         /// Data for the new link (edge) to be created.
         link_type: String,
         link_value: Option<String>, // Optional value for the new link
-
         /// Specifies the connection point for the link.
-        /// Exactly ONE of these must be Some, indicating the pre-existing vertex.
-        /// The other implicitly refers to the newly created vertex.
-        link_from_existing_id: Option<String>, // If Some, the link goes FROM this existing vertex TO the new one.
-        link_to_existing_id: Option<String>,   // If Some, the link goes FROM the new vertex TO this existing one.
+        /// Exactly ONE of these must be Some, indicating the pre-existing node.
+        /// The other implicitly refers to the newly created node.
+        link_from_existing_id: Option<String>, // If Some, the link goes FROM this existing node TO the new one.
+        link_to_existing_id: Option<String>,   // If Some, the link goes FROM the new node TO this existing one.
     },
 }
 

--- a/contracts/cw-graph/src/msg.rs
+++ b/contracts/cw-graph/src/msg.rs
@@ -54,6 +54,21 @@ pub enum ExecuteMsg {
     UpdateExecutors {
         new_executors: Vec<String>
     },
+    CreateVertexAndLink {
+        /// Data for the new vertex (node) to be created.
+        vertex_type: String,
+        vertex_value: Option<String>, // Optional value for the new vertex
+
+        /// Data for the new link (edge) to be created.
+        link_type: String,
+        link_value: Option<String>, // Optional value for the new link
+
+        /// Specifies the connection point for the link.
+        /// Exactly ONE of these must be Some, indicating the pre-existing vertex.
+        /// The other implicitly refers to the newly created vertex.
+        link_from_existing_id: Option<String>, // If Some, the link goes FROM this existing vertex TO the new one.
+        link_to_existing_id: Option<String>,   // If Some, the link goes FROM the new vertex TO this existing one.
+    },
 }
 
 #[cw_serde]

--- a/contracts/cw-graph/src/tests.rs
+++ b/contracts/cw-graph/src/tests.rs
@@ -1511,7 +1511,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_vertex_and_link() {
+    fn test_create_cyberlink2() {
         let mut deps = mock_dependencies();
         let admin = deps.api.addr_make("admin");
         let user = deps.api.addr_make("user");
@@ -1534,50 +1534,50 @@ mod tests {
 
         // Create an existing Thread by user
         let thread_res = execute(deps.as_mut(), mock_env(), message_info(&user, &[]), ExecuteMsg::CreateCyberlink { cyberlink: Cyberlink { type_: "Thread".to_string(), from: None, to: None, value: Some("Main Thread".to_string()) } }).unwrap();
-        let existing_thread_id = thread_res.attributes.iter().find(|a| a.key == "formatted_id").unwrap().value.clone();
+        let existing_thread_id = thread_res.attributes.iter().find(|a| a.key == "fid").unwrap().value.clone();
         assert_eq!(existing_thread_id, "Thread:1");
 
         // --- Test Case 1: Success - Create Message and link FROM new Message TO existing Thread ---
         let user_info = message_info(&user, &[]);
-        let msg = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("First message".to_string()),
+        let msg = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("First message".to_string()),
             link_type: "Replies".to_string(),
             link_value: None,
-            link_from_existing_id: None, // New vertex is FROM
+            link_from_existing_id: None, // New node is FROM
             link_to_existing_id: Some(existing_thread_id.clone()), // Link TO existing thread
         };
 
         let res = execute(deps.as_mut(), mock_env(), user_info.clone(), msg).unwrap();
         
         // Check response attributes
-        let new_vertex_id = res.attributes.iter().find(|a| a.key == "new_vertex_id").unwrap().value.clone();
-        let link_id = res.attributes.iter().find(|a| a.key == "link_id").unwrap().value.clone();
-        assert_eq!(new_vertex_id, "Message:1"); // First message
-        assert_eq!(link_id, "Replies:1"); // First reply link
-        assert_eq!(res.attributes[0].value, "create_vertex_and_link");
+        let node_fid = res.attributes.iter().find(|a| a.key == "node_fid").unwrap().value.clone(); // Updated key
+        let link_fid = res.attributes.iter().find(|a| a.key == "link_fid").unwrap().value.clone(); // Updated key
+        assert_eq!(node_fid, "Message:1"); // First message
+        assert_eq!(link_fid, "Replies:1"); // First reply link
+        assert_eq!(res.attributes[0].value, "create_cyberlink2"); // Renamed action attribute
 
-        // Verify created vertex (Message:1)
-        let query_vertex = QueryMsg::CyberlinkByID { id: new_vertex_id.clone() };
-        let vertex_res = query(deps.as_ref(), mock_env(), query_vertex).unwrap();
-        let vertex_state: CyberlinkState = from_json(&vertex_res).unwrap();
-        assert_eq!(vertex_state.type_, "Message");
-        assert_eq!(vertex_state.value, "First message");
-        assert_eq!(vertex_state.owner, user);
+        // Verify created node (Message:1)
+        let query_node = QueryMsg::CyberlinkByFID { fid: node_fid.clone() };
+        let node_res = query(deps.as_ref(), mock_env(), query_node).unwrap();
+        let node_state: CyberlinkState = from_json(&node_res).unwrap();
+        assert_eq!(node_state.type_, "Message");
+        assert_eq!(node_state.value, "First message");
+        assert_eq!(node_state.owner, user);
 
         // Verify created link (Replies:1)
-        let query_link = QueryMsg::CyberlinkByID { id: link_id.clone() };
+        let query_link = QueryMsg::CyberlinkByFID { fid: link_fid.clone() };
         let link_res = query(deps.as_ref(), mock_env(), query_link).unwrap();
         let link_state: CyberlinkState = from_json(&link_res).unwrap();
         assert_eq!(link_state.type_, "Replies");
-        assert_eq!(link_state.from, new_vertex_id);
+        assert_eq!(link_state.from, node_fid);
         assert_eq!(link_state.to, existing_thread_id);
         assert_eq!(link_state.owner, user);
 
         // --- Test Case 2: Error - Invalid Link Specification (both None) ---
-        let msg_invalid_spec1 = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("Invalid msg".to_string()),
+        let msg_invalid_spec1 = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("Invalid msg".to_string()),
             link_type: "Replies".to_string(),
             link_value: None,
             link_from_existing_id: None, // Error: both None
@@ -1587,9 +1587,9 @@ mod tests {
         assert!(matches!(err, ContractError::InvalidLinkSpecification {}));
 
         // --- Test Case 3: Error - Invalid Link Specification (both Some) ---
-        let msg_invalid_spec2 = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("Invalid msg".to_string()),
+        let msg_invalid_spec2 = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("Invalid msg".to_string()),
             link_type: "Replies".to_string(),
             link_value: None,
             link_from_existing_id: Some(existing_thread_id.clone()), // Error: both Some
@@ -1599,9 +1599,9 @@ mod tests {
         assert!(matches!(err, ContractError::InvalidLinkSpecification {}));
 
         // --- Test Case 4: Error - Link Type Not Exists ---
-        let msg_bad_link_type = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("Another message".to_string()),
+        let msg_bad_link_type = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("Another message".to_string()),
             link_type: "InvalidLinkType".to_string(), // This type doesn't exist
             link_value: None,
             link_from_existing_id: None,
@@ -1610,10 +1610,10 @@ mod tests {
         let err = execute(deps.as_mut(), mock_env(), user_info.clone(), msg_bad_link_type).unwrap_err();
         assert!(matches!(err, ContractError::TypeNotExists { type_: t } if t == "InvalidLinkType"));
 
-        // --- Test Case 5: Error - Existing Vertex Not Exists ---
-        let msg_bad_target = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("Another message".to_string()),
+        // --- Test Case 5: Error - Existing Node Not Exists ---
+        let msg_bad_target = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("Another message".to_string()),
             link_type: "Replies".to_string(),
             link_value: None,
             link_from_existing_id: None,
@@ -1623,9 +1623,9 @@ mod tests {
         assert!(matches!(err, ContractError::ToNotExists { to: t } if t == "Thread:999"));
 
         // --- Test Case 6: Error - Type Conflict (e.g., Replies expects Message -> Thread, try Thread -> Thread) ---
-         let msg_type_conflict = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Thread".to_string(), // Trying to create a Thread vertex...
-            vertex_value: Some("Nested Thread?".to_string()),
+         let msg_type_conflict = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Thread".to_string(), // Trying to create a Thread node...
+            node_value: Some("Nested Thread?".to_string()),
             link_type: "Replies".to_string(), // ... but link it using Replies (expects Message -> Thread)
             link_value: None,
             link_from_existing_id: None, // From new Thread
@@ -1634,31 +1634,31 @@ mod tests {
         let err = execute(deps.as_mut(), mock_env(), user_info.clone(), msg_type_conflict).unwrap_err();
         assert!(matches!(err, ContractError::TypeConflict { .. })); // Detailed check might be needed if specific fields matter
 
-        // --- Test Case 7: Success - Create vertex and link FROM existing TO new ---
+        // --- Test Case 7: Success - Create node and link FROM existing TO new ---
         // First, create another type "IsBasedOn" (e.g., Message -> Message)
         execute(deps.as_mut(), mock_env(), admin_info.clone(), ExecuteMsg::CreateNamedCyberlink { name: "IsBasedOn".to_string(), cyberlink: Cyberlink { type_: "Type".to_string(), from: Some("Message".to_string()), to: Some("Message".to_string()), value: None } }).unwrap();
 
         // Now create a new message based on Message:1
-        let msg_link_from_existing = ExecuteMsg::CreateVertexAndLink {
-            vertex_type: "Message".to_string(),
-            vertex_value: Some("Follow-up message".to_string()),
+        let msg_link_from_existing = ExecuteMsg::CreateCyberlink2 {
+            node_type: "Message".to_string(),
+            node_value: Some("Follow-up message".to_string()),
             link_type: "IsBasedOn".to_string(),
             link_value: None,
             link_from_existing_id: Some("Message:1".to_string()), // Link FROM Message:1
             link_to_existing_id: None, // TO the new message
         };
         let res = execute(deps.as_mut(), mock_env(), user_info.clone(), msg_link_from_existing).unwrap();
-        let new_vertex_id_2 = res.attributes.iter().find(|a| a.key == "new_vertex_id").unwrap().value.clone();
-        let link_id_2 = res.attributes.iter().find(|a| a.key == "link_id").unwrap().value.clone();
-        assert_eq!(new_vertex_id_2, "Message:2");
-        assert_eq!(link_id_2, "IsBasedOn:1");
+        let node_fid_2 = res.attributes.iter().find(|a| a.key == "node_fid").unwrap().value.clone(); // Updated key
+        let link_fid_2 = res.attributes.iter().find(|a| a.key == "link_fid").unwrap().value.clone(); // Updated key
+        assert_eq!(node_fid_2, "Message:2");
+        assert_eq!(link_fid_2, "IsBasedOn:1");
 
         // Verify link direction
-        let query_link = QueryMsg::CyberlinkByID { id: link_id_2.clone() };
+        let query_link = QueryMsg::CyberlinkByFID { fid: link_fid_2.clone() };
         let link_res = query(deps.as_ref(), mock_env(), query_link).unwrap();
         let link_state: CyberlinkState = from_json(&link_res).unwrap();
         assert_eq!(link_state.type_, "IsBasedOn");
         assert_eq!(link_state.from, "Message:1"); // From existing
-        assert_eq!(link_state.to, new_vertex_id_2); // To new
+        assert_eq!(link_state.to, node_fid_2); // To new
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature for creating cyberlinks with enhanced flexibility (`CreateCyberlink2`) and includes several updates to improve functionality, error handling, and testing. The most important changes are grouped into three themes: feature addition, error handling improvements, and testing enhancements.

### Feature Addition:
* Added a new `CreateCyberlink2` execution message to enable creating a new node and linking it to an existing node with more precise control over link direction and validation. This includes the implementation of the `execute_create_cyberlink2` function in `contracts/cw-graph/src/execute.rs` and the corresponding message definition in `contracts/cw-graph/src/msg.rs`. [[1]](diffhunk://#diff-08f87ee7259a97ae3b512e692de00b9c1920ff7c5b718898aa4a41240928d8d2L7-R7) [[2]](diffhunk://#diff-08f87ee7259a97ae3b512e692de00b9c1920ff7c5b718898aa4a41240928d8d2R121-R143) [[3]](diffhunk://#diff-40692fa0a07cdcde964c3265d31df726140404e789fd721370cab40120e3b4ccR57-R69) [[4]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81R403-R563)

### Error Handling Improvements:
* Enhanced the `ContractError` enum to include a new `InvalidLinkSpecification` error for cases where both `link_from_existing_id` and `link_to_existing_id` are either `None` or both `Some`. This ensures stricter validation of link specifications.
* Refined the `TypeConflict` error message for better readability and removed unused `id` fields from related error handling logic. [[1]](diffhunk://#diff-186452bd7621fa9d83b3e5d18a874dccab771f0b679dd6edb0fc6018a45d9ef0L25-R35) [[2]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81L48) [[3]](diffhunk://#diff-11c10969043f87ff011fd533d58d2307df1d203a29d6afdc7afbdb7929269d81L63)

### Testing Enhancements:
* Added comprehensive unit tests for the `CreateCyberlink2` functionality, covering various scenarios such as successful creation, invalid link specification, nonexistent link types, and type conflicts. These tests ensure robust validation and correct behavior of the new feature.